### PR TITLE
Fix bug of use_https flag in backend

### DIFF
--- a/.github/workflows/deployUI.yml
+++ b/.github/workflows/deployUI.yml
@@ -1,10 +1,10 @@
 # This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: deploy_to_github_pages
+name: CI-frontend
 
 on:
-  push:
+  pull_request:
     branches: ["master"]
 
 jobs:
@@ -27,7 +27,7 @@ jobs:
         with:
           payload: |
             {
-              "text": "*[http-chat-ui]* Start: Frontend deployment"
+              "text": "*[http-chat-ui]* Start: Frontend CI"
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -43,21 +43,13 @@ jobs:
         env:
           REACT_APP_GITHUB_CLIENT_ID: ${{ secrets.OAUTH_GITHUB_CLIENT_ID }}
           REACT_APP_BACKEND_BASEURL: ${{ secrets.BACKEND_BASEURL }}
-      - name: PostBuild
-        # reference: https://dev-yakuza.posstree.com/react/github-pages/#public_url
-        run: cp build/index.html build/404.html
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./ui/build
       - name: complete notification
         id: slack_complete
         uses: slackapi/slack-github-action@v1.22.0
         with:
           payload: |
             {
-              "text": "*[http-chat-ui]* Completed: Frontend deployment"
+              "text": "*[http-chat-ui]* Completed: Frontend CI"
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/api/login/oauth.py
+++ b/api/login/oauth.py
@@ -8,10 +8,9 @@ import requests
 from config import config
 
 # STAGEがdevelopでない場合、認証CookieをHTTPで利用できないよう制限
+use_https = True
 if config.stage == "develop":
     use_https = False
-else:
-    True
 
 
 class LoginOauthRequest(BaseModel):

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,7 +2,7 @@
     "name": "http-chat",
     "version": "0.1.0",
     "private": true,
-    "homepage": "https://iwsh.github.io/http-chat",
+    "homepage": "https://symitems-chat.onrender.com/",
     "dependencies": {
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.3.0",


### PR DESCRIPTION
STAGEにdevelop以外を指定した際に、oauth認証の際にErrorが発生し401が返却されていた。
正しく定義されていないuse_httpsを参照していたためRunTimeErrorが発生していたと考えられる