### PR TITLE
Fix timestamp to be displayed as Nan in JST

### DIFF
--- a/ui/src/components/Chat.js
+++ b/ui/src/components/Chat.js
@@ -102,9 +102,7 @@ export default function Chat() {
     switch (timezone) {
       case "JST":
         strDate = strDate + "Z"
-        const parseDate = Date.parse(strDate.replace(/-/g, "/").replace(/T/, " "));
-        const parsejstdate = parseDate;
-        const jstdate = new Date(parsejstdate);
+        const jstdate = new Date(Date.parse(strDate));
         return (
           [
             jstdate.getFullYear(),


### PR DESCRIPTION
iPhoneのsafariで正しく表示されない問題を解決しました
vivaldi (Windows)、Safari (iPhone)で動作を確認しています。