### PR TITLE
Use-reverse-proxy

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,7 +2,7 @@
 GITHUB_CLIENT_ID=xxxxxxxxxxxxxxxxxxx
 
 # ui envs
-BACKEND_BASEURL=http://localhost:8000
+BACKEND_BASEURL=http://api:8000
 
 # api envs
 STAGE=develop

--- a/.env.sample
+++ b/.env.sample
@@ -6,7 +6,6 @@ BACKEND_BASEURL=http://api:8000
 
 # api envs
 STAGE=develop
-UI_ORIGIN=http://localhost:3000
 GITHUB_CLIENT_SECRET=XXXXXXXXXXXXXXXXXXXXXXX
 PG_HOST=db.example.com
 PG_DATABASE=postgres

--- a/api/config.py
+++ b/api/config.py
@@ -4,7 +4,6 @@ import os
 class Config:
     def __init__(self):
         self.stage = os.getenv("STAGE")
-        self.origin = os.getenv("UI_ORIGIN", default="http://localhost:3000")
         self.secret_key = os.getenv("SECRET", default="my-secret")
         self.client_id = os.getenv("GITHUB_CLIENT_ID")
         self.client_secret = os.getenv("GITHUB_CLIENT_SECRET")

--- a/api/login/oauth.py
+++ b/api/login/oauth.py
@@ -43,16 +43,9 @@ class GithubOauth:
             token = jwt.encode(payload, self.secret_key, algorithm='HS256')
 
             # JWTトークンをcookieとして設定します。
-            # NOTE: developでsamesite属性を設定すると動かなくなるため暫定対応
-            #       よりよい実装があれば修正してください
-            if config.stage == "develop":
-                response.set_cookie(key="access_token", value=token,
-                                    # httponly=True, samesite="None",
-                                    secure=use_https)
-            else:
-                response.set_cookie(key="access_token", value=token,
-                                    httponly=True, samesite="None",
-                                    secure=use_https)
+            response.set_cookie(key="access_token", value=token,
+                                httponly=True, samesite="Strict",
+                                secure=use_https)
 
             return {
                 "message": "login successfully",

--- a/api/main.py
+++ b/api/main.py
@@ -1,19 +1,10 @@
 from fastapi import FastAPI
-from fastapi.middleware.cors import CORSMiddleware
 
 from login.oauth import GithubOauth
 from message.controller import MessageController
-from config import config
 
 
 app = FastAPI()
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=[config.origin],
-    allow_credentials=True,
-    allow_methods=["GET", "POST", "DELETE"],
-    allow_headers=["*"],
-)
 
 app.include_router(GithubOauth().router)
 app.include_router(MessageController().router)
@@ -21,4 +12,4 @@ app.include_router(MessageController().router)
 
 @app.get("/")
 def read_root():
-    return {"status": config.origin}
+    return {"status": "ok"}

--- a/docker-compose.develop.yml
+++ b/docker-compose.develop.yml
@@ -20,14 +20,12 @@ services:
       - api
     environment:
       - REACT_APP_GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID}
-      - REACT_APP_BACKEND_BASEURL=http://localhost:8000
+      - REACT_APP_BACKEND_BASEURL=http://api:8000
   api:
     build:
       context: api
     volumes:
       - ./api:/app
-    ports:
-      - "8000:8000"
     environment:
       - PG_HOST=db
       - PG_DATABASE=postgres

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -18,14 +18,13 @@ services:
       - "3000:3000"
     depends_on:
       - api
-    env_file:
-      - .env
+    environment:
+      - REACT_APP_GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID}
+      - REACT_APP_BACKEND_BASEURL=http://api:8000
   api:
     build:
       context: ./api
     volumes:
       - ./api:/app
-    ports:
-      - "8000:8000"
     env_file:
       - .env

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -17,6 +17,9 @@
                 "react-router-dom": "^6.8.0",
                 "react-scripts": "5.0.1",
                 "web-vitals": "^2.1.4"
+            },
+            "devDependencies": {
+                "http-proxy-middleware": "^2.0.6"
             }
         },
         "node_modules/@adobe/css-tools": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -37,5 +37,8 @@
             "last 1 firefox version",
             "last 1 safari version"
         ]
+    },
+    "devDependencies": {
+        "http-proxy-middleware": "^2.0.6"
     }
 }

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Route, Navigate, Routes, BrowserRouter } from 'react-router-dom';
-import { useAuth } from './context/AuthContext';
+import { is_authenticated } from './context/AuthContext';
 
 const Login = React.lazy(() => import('./components/Login'));
 const Chat = React.lazy(() => import('./components/Chat'));
@@ -24,7 +24,5 @@ export default function App() {
 }
 
 function PrivateRoute(props) {
-  const { is_authenticated } = useAuth();
-
   return is_authenticated() ? props.children : <Navigate to="/login" />;
 }

--- a/ui/src/components/Chat.js
+++ b/ui/src/components/Chat.js
@@ -1,14 +1,11 @@
 import '../App.css';
 import React, { useEffect, useRef, useState, useCallback } from "react";
 import { useNavigate } from "react-router";
-import axios from "axios";
-import { useAuth } from '../context/AuthContext';
-
-const backend_baseurl = process.env.REACT_APP_BACKEND_BASEURL
+import { logout } from '../context/AuthContext';
+import { backend_api } from "../helper/ApiHelper";
 
 export default function Chat() {
   const navigate = useNavigate();
-  const logout = useAuth().logout;
   const [msgs, setMsgs] = useState([]);
   const [post, setPost] = useState({});
   const [timezone, setTimezone] = useState();
@@ -19,14 +16,13 @@ export default function Chat() {
     { value: "JST", label: "JST" },
   ];
 
-  axios.defaults.withCredentials = true;
 
   const logoutAndNavigateLogin = useCallback(() => {
     logout();
     setTimeout(() => {
       navigate("/login");
     }, 100)
-  }, [logout, navigate]);
+  }, [navigate]);
 
 
   const handleText = (event) => {
@@ -39,7 +35,7 @@ export default function Chat() {
 
   useEffect(() => {
     const interval = setInterval(() => {
-      axios.get(backend_baseurl + "/messages/")
+      backend_api.get("/messages/")
         .then((res) => {
           console.log(res);
           setMsgs(res.data);
@@ -63,8 +59,7 @@ export default function Chat() {
       const _post = { text: text };
 
       // POST処理
-      axios
-        .post(backend_baseurl + "/messages/", _post)
+      backend_api.post("/messages/", _post)
         .then((res) => {
           console.log(res);
           setMsgs(res.data);
@@ -84,8 +79,7 @@ export default function Chat() {
 
   const clickClear = () => {
     // DELETE処理
-    axios
-      .delete(backend_baseurl + "/messages/")
+    backend_api.delete("/messages/")
       .then((res) => {
         console.log(res);
         setMsgs(res.data);

--- a/ui/src/components/Login.js
+++ b/ui/src/components/Login.js
@@ -2,21 +2,17 @@ import '../App.css';
 import logo from '../logo.svg';
 import { useState, useEffect, useCallback } from "react";
 import { useNavigate } from "react-router";
-import axios from "axios";
-import { useAuth } from '../context/AuthContext';
+import { login } from '../context/AuthContext';
+import { backend_api } from "../helper/ApiHelper";
 
-const backend_baseurl = process.env.REACT_APP_BACKEND_BASEURL
 
 export default function Login() {
   const navigate = useNavigate();
-  const login = useAuth().login;
   const [error, setError] = useState("");
 
   const [message, setMessage] = useState("")
   const github_client_id = process.env.REACT_APP_GITHUB_CLIENT_ID
   const github_oauth_url = `https://github.com/login/oauth/authorize?client_id=${github_client_id}&scope=user:read`
-
-  axios.defaults.withCredentials = true;
 
   const loginAndNavigate = useCallback(() => {
     login();
@@ -24,14 +20,14 @@ export default function Login() {
     setTimeout(() => {
       navigate("/chat");
     }, 100)
-  }, [login, navigate])
+  }, [navigate])
 
   useEffect(() => {
     const params = window.location.search;
     const code = params.startsWith('?code=') ? params.split('=')[1] : undefined;
     if (code) {
       setMessage("Verifying account...")
-      axios.post(backend_baseurl + '/login/oauth/github', {
+      backend_api.post('/login/oauth/github', {
         code: code
       }, {
         headers: {

--- a/ui/src/context/AuthContext.js
+++ b/ui/src/context/AuthContext.js
@@ -1,17 +1,13 @@
-export const useAuth = () => {
-  const key = "is_authenticated";
+const key = "is_authenticated";
 
-  const is_authenticated = () => {
-    return sessionStorage.getItem(key);
-  }
+export const is_authenticated = () => {
+  return sessionStorage.getItem(key);
+}
 
-  const login = () => {
-    sessionStorage.setItem(key, true)
-  };
+export const login = () => {
+  sessionStorage.setItem(key, true)
+};
 
-  const logout = () => {
-    sessionStorage.removeItem(key);
-  };
-
-  return { is_authenticated, login, logout };
+export const logout = () => {
+  sessionStorage.removeItem(key);
 };

--- a/ui/src/helper/ApiHelper.js
+++ b/ui/src/helper/ApiHelper.js
@@ -1,0 +1,6 @@
+import axios from "axios";
+
+export const backend_api = axios.create({
+    baseURL: "/api/",
+    withCredentials: true,
+});

--- a/ui/src/setupProxy.js
+++ b/ui/src/setupProxy.js
@@ -1,0 +1,17 @@
+// NOTE: This file enables reverse proxy for backend API in development server
+//       Rewrite setting is needed in the case of production build.
+//       ref.) https://www.npmjs.com/package/http-proxy-middleware
+
+const { createProxyMiddleware } = require("http-proxy-middleware");
+
+module.exports = function (app) {
+    const backend_baseurl = process.env.REACT_APP_BACKEND_BASEURL
+    app.use(
+        "/api",
+        createProxyMiddleware({
+            target: backend_baseurl,
+            pathRewrite: { '^/api/': '/' },
+            changeOrigin: true,
+        })
+    );
+};


### PR DESCRIPTION
Backend API へフロントエンドと同じホスト名から Proxy 経由でアクセスするように変更しました。
これにより FastAPI での Frontend のオリジンを指定しての CORS 許可の実装が不要になり、また、 Cross-Site 属性を持つ Cookie が不要となりました。

この変更により、iPhone などで「サイト越えトラッキングを防ぐ」の設定がされていてもアクセス可能になることが期待できます。