### PR TITLE
Allow connection to port 8000 in Azure App Service

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -15,4 +15,4 @@ RUN chmod +x /usr/local/bin/wait-for-it.sh
 
 
 COPY . .
-CMD [ "uvicorn", "main:app", "--host", "0.0.0.0" ]
+CMD [ "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000" ]

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -15,4 +15,5 @@ RUN chmod +x /usr/local/bin/wait-for-it.sh
 
 
 COPY . .
-CMD [ "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000" ]
+EXPOSE 8000
+CMD [ "uvicorn", "main:app", "--host", "0.0.0.0"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,8 +51,6 @@ services:
       - "--reload"
       - "--host"
       - "0.0.0.0"
-      - "--port"
-      - "8000"
     depends_on:
       - db
   db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,8 @@ services:
       - "--reload"
       - "--host"
       - "0.0.0.0"
+      - "--port"
+      - "8000"
     depends_on:
       - db
   db:


### PR DESCRIPTION
App Service のエンドポイントURLにアクセスした時に、リバースプロキシ経由で FastAPI の8000番ポートへの疎通にも対応できるように、Docker関連のファイルを修正しました。