### PR TITLE
Format UTC with seconds precision

### DIFF
--- a/ui/src/pages/Chat.js
+++ b/ui/src/pages/Chat.js
@@ -122,10 +122,10 @@ export default function Chat() {
   };
 
   const changeTimezone = (strDate) => {
+    strDate = strDate + "Z"
+    const jstdate = new Date(Date.parse(strDate));
     switch (timezone) {
       case "JST":
-        strDate = strDate + "Z"
-        const jstdate = new Date(Date.parse(strDate));
         return (
           [
             jstdate.getFullYear(),
@@ -140,7 +140,19 @@ export default function Chat() {
           ].join(":")
         );
       default:
-        return strDate;
+        return (
+          [
+            jstdate.getUTCFullYear(),
+            ("0" + (jstdate.getUTCMonth() + 1)).slice(-2),
+            ("0" + jstdate.getUTCDate()).slice(-2),
+          ].join("-") +
+          " " +
+          [
+            ("0" + jstdate.getUTCHours()).slice(-2),
+            ("0" + jstdate.getUTCMinutes()).slice(-2),
+            ("0" + jstdate.getUTCSeconds()).slice(-2),
+          ].join(":")
+        );
     }
   };
 

--- a/ui/src/pages/Chat.js
+++ b/ui/src/pages/Chat.js
@@ -123,34 +123,34 @@ export default function Chat() {
 
   const changeTimezone = (strDate) => {
     strDate = strDate + "Z"
-    const jstdate = new Date(Date.parse(strDate));
+    const date = new Date(Date.parse(strDate));
     switch (timezone) {
       case "JST":
         return (
           [
-            jstdate.getFullYear(),
-            ("0" + (jstdate.getMonth() + 1)).slice(-2),
-            ("0" + jstdate.getDate()).slice(-2),
+            date.getFullYear(),
+            ("0" + (date.getMonth() + 1)).slice(-2),
+            ("0" + date.getDate()).slice(-2),
           ].join("-") +
           " " +
           [
-            ("0" + jstdate.getHours()).slice(-2),
-            ("0" + jstdate.getMinutes()).slice(-2),
-            ("0" + jstdate.getSeconds()).slice(-2),
+            ("0" + date.getHours()).slice(-2),
+            ("0" + date.getMinutes()).slice(-2),
+            ("0" + date.getSeconds()).slice(-2),
           ].join(":")
         );
       default:
         return (
           [
-            jstdate.getUTCFullYear(),
-            ("0" + (jstdate.getUTCMonth() + 1)).slice(-2),
-            ("0" + jstdate.getUTCDate()).slice(-2),
+            date.getUTCFullYear(),
+            ("0" + (date.getUTCMonth() + 1)).slice(-2),
+            ("0" + date.getUTCDate()).slice(-2),
           ].join("-") +
           " " +
           [
-            ("0" + jstdate.getUTCHours()).slice(-2),
-            ("0" + jstdate.getUTCMinutes()).slice(-2),
-            ("0" + jstdate.getUTCSeconds()).slice(-2),
+            ("0" + date.getUTCHours()).slice(-2),
+            ("0" + date.getUTCMinutes()).slice(-2),
+            ("0" + date.getUTCSeconds()).slice(-2),
           ].join(":")
         );
     }


### PR DESCRIPTION
UTCの表示がマイクロ秒まで表示されていたので、小数点以下を切り捨てて秒までを表示するように改修してます。